### PR TITLE
Remove matrix in release workflow

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -34,11 +34,11 @@ template: |
   - **protoc-gen-grpc-python-linux-x86_64**: Linux x86_64
   - **protoc-gen-grpc-python-macos-x86_64**: macOS Intel
   - **protoc-gen-grpc-python-macos-arm64**: macOS Apple Silicon
-  - **checksums-$RESOLVED_VERSION.txt**: SHA256 checksums
+  - **checksums.txt**: SHA256 checksums
 
   ## Verification
 
   Verify the downloaded binary using SHA256:
   ```bash
-  sha256sum -c checksums-$RESOLVED_VERSION.txt
+  sha256sum -c checksums.txt
   ```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,36 +9,18 @@ on:
         type: string
 
 jobs:
-  get-versions:
-    runs-on: ubuntu-24.04
-    outputs:
-      versions: ${{ steps.extract-versions.outputs.versions }}
-    steps:
-      - name: Extract unique versions
-        id: extract-versions
-        run: |
-          # Extract unique gRPC versions from the matrix
-          versions=$(echo '${{ inputs.matrix }}' | jq -r '.include[].grpc_version' | sort -u | jq -R . | jq -s . -c)
-          echo "versions=$versions" >> $GITHUB_OUTPUT
-          echo "Extracted versions: $versions"
-
   release:
-    needs: [get-versions]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
-    strategy:
-      matrix:
-        grpc_version: ${{ fromJson(needs.get-versions.outputs.versions) }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download all artifacts for version
+      - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: "*-${{ matrix.grpc_version }}"
           merge-multiple: true
           path: release-artifacts
 
@@ -52,11 +34,11 @@ jobs:
         run: |
           for file in *; do
             if [[ -f "$file" ]]; then
-              sha256sum "$file" >> checksums-${{ matrix.grpc_version }}.txt
+              sha256sum "$file" >> checksums.txt
             fi
           done
           echo "Checksums:"
-          cat checksums-${{ matrix.grpc_version }}.txt
+          cat checksums.txt
 
       - name: Ensure draft release exists
         id: check-draft


### PR DESCRIPTION
So we have one merged release instead of one per gRPC version