### PR TITLE
Combine macOS builds

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -34,8 +34,7 @@ template: |
   This release contains binaries for multiple gRPC versions. Each binary is named with the format `protoc-gen-grpc-python-{platform}-{grpc_version}`:
 
   - **protoc-gen-grpc-python-linux-x86_64-{version}**: Linux x86_64
-  - **protoc-gen-grpc-python-macos-x86_64-{version}**: macOS Intel
-  - **protoc-gen-grpc-python-macos-arm64-{version}**: macOS Apple Silicon
+  - **protoc-gen-grpc-python-macos-universal-{version}**: macOS Universal (Intel + Apple Silicon)
   - **checksums.txt**: SHA256 checksums for all binaries
 
   ## Verification

--- a/grpc-versions.yaml
+++ b/grpc-versions.yaml
@@ -40,12 +40,8 @@ platforms:
   os: ubuntu-24.04
   bazel_config: --config=linux
   artifact_name: protoc-gen-grpc-python-linux-x86_64
-- name: macos-x86_64
-  os: macos-13
-  bazel_config: --config=macos
-  artifact_name: protoc-gen-grpc-python-macos-x86_64
-- name: macos-arm64
+- name: macos-universal
   os: macos-15
   bazel_config: --config=macos
-  artifact_name: protoc-gen-grpc-python-macos-arm64
+  artifact_name: protoc-gen-grpc-python-macos-universal
 


### PR DESCRIPTION
Since gRPC builds universal binaries, we don't need to build this twice.

Fixes #13